### PR TITLE
Added Manage Matches section to Admin Dashboard

### DIFF
--- a/mentor-match-app/src/api/match.js
+++ b/mentor-match-app/src/api/match.js
@@ -156,12 +156,20 @@ export const getAllMentorshipPairs = async () => {
     const usersCol = collection(db, 'users')
     const snapshot = await getDocs(usersCol)
     const pairs = []
-    snapshot.forEach((docSnap) => {
+    for (const docSnap of snapshot.docs) {
       const data = docSnap.data()
       if (data.mentorId) {
-        pairs.push({ menteeId: docSnap.id, mentorId: data.mentorId })
+        const mentorDocRef = doc(db, 'users', data.mentorId)
+        const pair = await getDoc(mentorDocRef)
+        if (
+          pair.exists() &&
+          Array.isArray(pair.data().menteesId) &&
+          pair.data().menteesId.includes(docSnap.id)
+        ) {
+          pairs.push({ menteeId: docSnap.id, mentorId: data.mentorId })
+        }
       }
-    })
+    }
     return pairs
   } catch (err) {
     console.error('Error fetching mentorship pairs:', err)

--- a/mentor-match-app/src/api/users.js
+++ b/mentor-match-app/src/api/users.js
@@ -40,7 +40,7 @@ export const getUserById = async (userId) => {
     return { ...user.data(), uid: user.id }
   } catch (err) {
     console.error('Error fetching user:', err)
-    return { ok: false, error: err.message }
+    return null
   }
 }
 

--- a/mentor-match-app/src/components/adminDashboard/ManageMatchesSection.jsx
+++ b/mentor-match-app/src/components/adminDashboard/ManageMatchesSection.jsx
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react'
+import {
+  Stack,
+  Typography,
+  Card,
+  Grid2 as Grid,
+  IconButton
+} from '@mui/material'
+import { Add as AddIcon } from '@mui/icons-material'
+import MatchGrid from './MatchGrid'
+import CreateNewMatchDialog from '../dialogs/CreateNewMatchDialog'
+import { getAllMentorshipPairs } from '../../api/match'
+
+const ManageMatchesSection = () => {
+  const [mentorshipPairs, setMentorshipPairs] = useState([])
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [reloadList, setReloadList] = useState(true) // start true to load initially
+
+  useEffect(() => {
+    if (!reloadList) return
+    const fetchPairs = async () => {
+      const pairs = await getAllMentorshipPairs()
+      setMentorshipPairs(pairs)
+      setReloadList(false)
+      console.log('Fetched mentorship pairs:', pairs)
+    }
+    fetchPairs()
+  }, [reloadList])
+
+  return (
+    <Stack spacing={2} width="100%">
+      <Grid container spacing={1}>
+        <Grid size={1.7}>
+          <Card
+            sx={{
+              height: '100%',
+              transition: 'box-shadow 0.3s',
+              '&:hover': {
+                boxShadow: 2
+              }
+            }}
+            variant="outlined"
+          >
+            <Stack
+              height={'100%'}
+              justifyContent={'center'}
+              alignItems="center"
+              spacing={1}
+              p={2}
+            >
+              <IconButton
+                sx={{ alignSelf: 'center' }}
+                onClick={() => setDialogOpen(true)}
+              >
+                <AddIcon fontSize="large" color="primary" />
+              </IconButton>
+              <Typography variant="body2" textAlign={'center'}>
+                Create New Match
+              </Typography>
+            </Stack>
+          </Card>
+        </Grid>
+        {mentorshipPairs.map((pair, idx) => (
+          <MatchGrid
+            key={`match-${pair.id ?? idx}`}
+            menteeId={pair.menteeId}
+            mentorId={pair.mentorId}
+            gridSize={1.7}
+            setReloadList={setReloadList}
+          />
+        ))}
+      </Grid>
+      <CreateNewMatchDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        setReloadList={setReloadList}
+      />
+    </Stack>
+  )
+}
+
+export default ManageMatchesSection

--- a/mentor-match-app/src/components/adminDashboard/MatchGrid.jsx
+++ b/mentor-match-app/src/components/adminDashboard/MatchGrid.jsx
@@ -9,12 +9,16 @@ import {
   IconButton,
   Tooltip
 } from '@mui/material'
-import { DeleteForever as DeleteIcon } from '@mui/icons-material'
+import {
+  DeleteForever as DeleteIcon,
+  Edit as EditIcon
+} from '@mui/icons-material'
 import ProfilePicture from '../ProfilePicture'
 import { useTheme } from '@mui/material/styles'
 import { getUserById } from '../../api/users'
 import EndMentorshipDialog from '../dialogs/EndMentorshipDialog'
 import UserProfileDialog from '../profile/UserProfileDialog'
+import CreateNewMatchDialog from '../dialogs/CreateNewMatchDialog'
 
 const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
   const [mentee, setMentee] = useState(null)
@@ -23,6 +27,7 @@ const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
   const [endMentorshipDialogOpen, setEndMentorshipDialogOpen] = useState(false)
   const [menteeProfileOpen, setMenteeProfileOpen] = useState(false)
   const [mentorProfileOpen, setMentorProfileOpen] = useState(false)
+  const [openCreateMatchDialog, setOpenCreateMatchDialog] = useState(false)
   const wasDialogOpen = useRef(false) // track previous state
 
   useEffect(() => {
@@ -143,12 +148,24 @@ const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
               </Stack>
             </Stack>
             <Box alignSelf={'flex-end'} maxHeight={'min-content'}>
+              <Tooltip title="Reassign Mentorship">
+                <IconButton onClick={() => setOpenCreateMatchDialog(true)}>
+                  <EditIcon fontSize="small" color="primary" />
+                </IconButton>
+              </Tooltip>
               <Tooltip title="End Mentorship">
                 <IconButton onClick={() => setEndMentorshipDialogOpen(true)}>
                   <DeleteIcon fontSize="small" color="error" />
                 </IconButton>
               </Tooltip>
             </Box>
+            <CreateNewMatchDialog
+              open={openCreateMatchDialog}
+              onClose={() => setOpenCreateMatchDialog(false)}
+              setReloadList={setReloadList}
+              mentor={mentor}
+              mentee={mentee}
+            />
             <EndMentorshipDialog
               openDialog={endMentorshipDialogOpen}
               setOpenDialog={setEndMentorshipDialogOpen}

--- a/mentor-match-app/src/components/adminDashboard/MatchGrid.jsx
+++ b/mentor-match-app/src/components/adminDashboard/MatchGrid.jsx
@@ -14,12 +14,15 @@ import ProfilePicture from '../ProfilePicture'
 import { useTheme } from '@mui/material/styles'
 import { getUserById } from '../../api/users'
 import EndMentorshipDialog from '../dialogs/EndMentorshipDialog'
+import UserProfileDialog from '../profile/UserProfileDialog'
 
 const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
   const [mentee, setMentee] = useState(null)
   const [mentor, setMentor] = useState(null)
   const [loading, setLoading] = useState(true)
   const [endMentorshipDialogOpen, setEndMentorshipDialogOpen] = useState(false)
+  const [menteeProfileOpen, setMenteeProfileOpen] = useState(false)
+  const [mentorProfileOpen, setMentorProfileOpen] = useState(false)
   const wasDialogOpen = useRef(false) // track previous state
 
   useEffect(() => {
@@ -51,12 +54,7 @@ const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
     <Grid size={gridSize}>
       <Card
         sx={{
-          height: '100%',
-          transition: 'box-shadow 0.3s',
-          '&:hover': {
-            boxShadow: 2,
-            cursor: 'pointer'
-          }
+          height: '100%'
         }}
         variant="outlined"
       >
@@ -92,12 +90,56 @@ const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
               <Stack spacing={1}>
                 <Stack spacing={0.1}>
                   <Typography variant="caption">Mentor</Typography>
-                  <Typography variant="body2">{mentor?.displayName}</Typography>
+                  <Tooltip title="View Profile">
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        '&:hover': {
+                          cursor: 'pointer',
+                          color: 'primary.main',
+                          fontWeight: 'medium'
+                        }
+                      }}
+                      onClick={() => setMentorProfileOpen(true)}
+                    >
+                      {mentor?.displayName}
+                    </Typography>
+                  </Tooltip>
                 </Stack>
+                <UserProfileDialog
+                  openDialog={mentorProfileOpen}
+                  setOpenDialog={setMentorProfileOpen}
+                  userId={mentor.uid}
+                  showChatButton={false}
+                  showEndMentorshipButton={false}
+                  showSelectAsMentorButton={false}
+                />
                 <Stack spacing={0.1}>
                   <Typography variant="caption">Mentee</Typography>
-                  <Typography variant="body2">{mentee?.displayName}</Typography>
+                  <Tooltip title="View Profile">
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        '&:hover': {
+                          cursor: 'pointer',
+                          color: 'primary.main',
+                          fontWeight: 'medium'
+                        }
+                      }}
+                      onClick={() => setMenteeProfileOpen(true)}
+                    >
+                      {mentee?.displayName}
+                    </Typography>
+                  </Tooltip>
                 </Stack>
+                <UserProfileDialog
+                  openDialog={menteeProfileOpen}
+                  setOpenDialog={setMenteeProfileOpen}
+                  userId={mentee.uid}
+                  showChatButton={false}
+                  showEndMentorshipButton={false}
+                  showSelectAsMentorButton={false}
+                />
               </Stack>
             </Stack>
             <Box alignSelf={'flex-end'} maxHeight={'min-content'}>

--- a/mentor-match-app/src/components/adminDashboard/MatchGrid.jsx
+++ b/mentor-match-app/src/components/adminDashboard/MatchGrid.jsx
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  Grid2 as Grid,
+  Stack,
+  Typography,
+  Box,
+  Card,
+  CircularProgress,
+  IconButton,
+  Tooltip
+} from '@mui/material'
+import { DeleteForever as DeleteIcon } from '@mui/icons-material'
+import ProfilePicture from '../ProfilePicture'
+import { useTheme } from '@mui/material/styles'
+import { getUserById } from '../../api/users'
+import EndMentorshipDialog from '../dialogs/EndMentorshipDialog'
+
+const MatchGrid = ({ menteeId, mentorId, gridSize = 4, setReloadList }) => {
+  const [mentee, setMentee] = useState(null)
+  const [mentor, setMentor] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [endMentorshipDialogOpen, setEndMentorshipDialogOpen] = useState(false)
+  const wasDialogOpen = useRef(false) // track previous state
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      const menteeData = await getUserById(menteeId)
+      const mentorData = await getUserById(mentorId)
+      setMentee(menteeData)
+      setMentor(mentorData)
+      console.log('Setting loading to false, fetched data:', {
+        menteeData,
+        mentorData
+      })
+      setLoading(false)
+    }
+    fetchUserData()
+  }, [menteeId, mentorId])
+
+  useEffect(() => {
+    if (wasDialogOpen.current && !endMentorshipDialogOpen) {
+      console.log('EndMentorshipDialog closed, refreshing list')
+      setReloadList(true)
+    }
+    wasDialogOpen.current = endMentorshipDialogOpen
+  }, [endMentorshipDialogOpen, setReloadList])
+
+  const theme = useTheme()
+  const borderColor = theme.palette.background.paper
+  return (
+    <Grid size={gridSize}>
+      <Card
+        sx={{
+          height: '100%',
+          transition: 'box-shadow 0.3s',
+          '&:hover': {
+            boxShadow: 2,
+            cursor: 'pointer'
+          }
+        }}
+        variant="outlined"
+      >
+        {loading ? (
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            height="100%"
+          >
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Stack spacing={1} p={2} sx={{ height: '100%' }}>
+            <Stack spacing={2} sx={{ height: '100%' }}>
+              <Box alignSelf="center" display="flex">
+                <ProfilePicture
+                  img={mentor?.profilePicture}
+                  size={60}
+                  borderRadius={100}
+                />
+                <ProfilePicture
+                  img={mentee?.profilePicture}
+                  size={60}
+                  borderRadius={100}
+                  props={{
+                    mt: 3,
+                    ml: -2,
+                    border: `3px solid ${borderColor}`
+                  }}
+                />
+              </Box>
+              <Stack spacing={1}>
+                <Stack spacing={0.1}>
+                  <Typography variant="caption">Mentor</Typography>
+                  <Typography variant="body2">{mentor?.displayName}</Typography>
+                </Stack>
+                <Stack spacing={0.1}>
+                  <Typography variant="caption">Mentee</Typography>
+                  <Typography variant="body2">{mentee?.displayName}</Typography>
+                </Stack>
+              </Stack>
+            </Stack>
+            <Box alignSelf={'flex-end'} maxHeight={'min-content'}>
+              <Tooltip title="End Mentorship">
+                <IconButton onClick={() => setEndMentorshipDialogOpen(true)}>
+                  <DeleteIcon fontSize="small" color="error" />
+                </IconButton>
+              </Tooltip>
+            </Box>
+            <EndMentorshipDialog
+              openDialog={endMentorshipDialogOpen}
+              setOpenDialog={setEndMentorshipDialogOpen}
+              menteeId={menteeId}
+              mentorId={mentorId}
+            />
+          </Stack>
+        )}
+      </Card>
+    </Grid>
+  )
+}
+
+export default MatchGrid

--- a/mentor-match-app/src/components/dashboard/ApplicationStatus.jsx
+++ b/mentor-match-app/src/components/dashboard/ApplicationStatus.jsx
@@ -197,78 +197,86 @@ const ApplicationStatus = () => {
                   </DialogActions>
                 </Dialog>
                 {/* SubmittedFormsSection end */}
-                <Divider sx={{ pt: 2, width: '20%', alignSelf: 'center' }} />
+
                 {applicationInfo && (
-                  <Stack spacing={1} sx={{ pt: 2 }}>
-                    <Typography fontWeight={'medium'}>
-                      Application Details
-                    </Typography>
-                    <Stack
-                      direction={'row'}
-                      spacing={0.5}
-                      alignItems={'center'}
-                    >
-                      {applicationInfo.status === 'pending' && (
-                        <PendingIcon fontSize="small" color="warning" />
-                      )}
-                      {applicationInfo.status === 'approved' && (
-                        <ApprovedIcon fontSize="small" color="success" />
-                      )}
-                      {applicationInfo.status === 'rejected' && (
-                        <RejectedIcon fontSize="small" color="error" />
-                      )}
-                      <Typography variant={'body2'}>
-                        Status: {capitalizeFirst(applicationInfo.status)}
+                  <>
+                    <Divider
+                      sx={{ pt: 2, width: '20%', alignSelf: 'center' }}
+                    />
+                    <Stack spacing={1} sx={{ pt: 2 }}>
+                      <Typography fontWeight={'medium'}>
+                        Application Details
                       </Typography>
-                    </Stack>
-                    {applicationInfo.status === 'rejected' &&
-                      applicationInfo.adminNotes && (
-                        <Stack spacing={1.75} direction={'row'}>
-                          <Divider
-                            orientation="vertical"
-                            flexItem
-                            sx={{ pl: 1.25 }}
-                          />
-                          <Stack spacing={0.5}>
-                            <Stack direction={'row'} spacing={0.5}>
-                              <Typography
-                                fontWeight={'medium'}
-                                variant={'body2'}
-                              >
-                                Reason for rejection:
-                              </Typography>
-                              <Typography variant={'body2'}>
-                                "{applicationInfo.adminNotes}"
+                      <Stack
+                        direction={'row'}
+                        spacing={0.5}
+                        alignItems={'center'}
+                      >
+                        {applicationInfo.status === 'pending' && (
+                          <PendingIcon fontSize="small" color="warning" />
+                        )}
+                        {applicationInfo.status === 'approved' && (
+                          <ApprovedIcon fontSize="small" color="success" />
+                        )}
+                        {applicationInfo.status === 'rejected' && (
+                          <RejectedIcon fontSize="small" color="error" />
+                        )}
+                        <Typography variant={'body2'}>
+                          Status: {capitalizeFirst(applicationInfo.status)}
+                        </Typography>
+                      </Stack>
+                      {applicationInfo.status === 'rejected' &&
+                        applicationInfo.adminNotes && (
+                          <Stack spacing={1.75} direction={'row'}>
+                            <Divider
+                              orientation="vertical"
+                              flexItem
+                              sx={{ pl: 1.25 }}
+                            />
+                            <Stack spacing={0.5}>
+                              <Stack direction={'row'} spacing={0.5}>
+                                <Typography
+                                  fontWeight={'medium'}
+                                  variant={'body2'}
+                                >
+                                  Reason for rejection:
+                                </Typography>
+                                <Typography variant={'body2'}>
+                                  "{applicationInfo.adminNotes}"
+                                </Typography>
+                              </Stack>
+                              <Typography variant={'caption'} color="error">
+                                Please address the issues mentioned above and
+                                resubmit your application by clicking "Edit
+                                Form".
                               </Typography>
                             </Stack>
-                            <Typography variant={'caption'} color="error">
-                              Please address the issues mentioned above and
-                              resubmit your application by clicking "Edit Form".
-                            </Typography>
                           </Stack>
-                        </Stack>
-                      )}
-                    <Stack
-                      direction={'row'}
-                      spacing={0.5}
-                      alignItems={'center'}
-                    >
-                      <DateIcon fontSize="small" color="primary" />
-                      <Typography variant={'body2'}>
-                        Submitted on: {formatDate(applicationInfo.submittedAt)}
-                      </Typography>
+                        )}
+                      <Stack
+                        direction={'row'}
+                        spacing={0.5}
+                        alignItems={'center'}
+                      >
+                        <DateIcon fontSize="small" color="primary" />
+                        <Typography variant={'body2'}>
+                          Submitted on:{' '}
+                          {formatDate(applicationInfo.submittedAt)}
+                        </Typography>
+                      </Stack>
+                      <Stack
+                        direction={'row'}
+                        spacing={0.5}
+                        alignItems={'center'}
+                      >
+                        <UpdateIcon fontSize="small" color="primary" />
+                        <Typography variant={'body2'}>
+                          Last updated:{' '}
+                          {formatDate(applicationInfo.lastUpdated)}
+                        </Typography>
+                      </Stack>
                     </Stack>
-                    <Stack
-                      direction={'row'}
-                      spacing={0.5}
-                      alignItems={'center'}
-                    >
-                      <UpdateIcon fontSize="small" color="primary" />
-                      <Typography variant={'body2'}>
-                        Last updated: {formatDate(applicationInfo.lastUpdated)}
-                      </Typography>
-                    </Stack>
-                  </Stack>
+                  </>
                 )}
               </Stack>
             )}

--- a/mentor-match-app/src/components/dashboard/MatchAlert.jsx
+++ b/mentor-match-app/src/components/dashboard/MatchAlert.jsx
@@ -4,7 +4,7 @@ import { CheckCircleOutlined as CheckCircleIcon } from '@mui/icons-material'
 import { useUser } from '../../hooks/useUser'
 import { updateNewMatchNotification } from '../../api/match'
 
-const MatchAlert = ({ setView }) => {
+const MatchAlert = ({ setView, setShowAlert }) => {
   const navigate = useNavigate()
   const { user } = useUser()
 
@@ -21,6 +21,7 @@ const MatchAlert = ({ setView }) => {
           console.error('Error updating new match notification:', error)
         })
       setView('currentMentees')
+      setShowAlert(false)
     }
   }
 

--- a/mentor-match-app/src/components/dashboard/SearchBar.jsx
+++ b/mentor-match-app/src/components/dashboard/SearchBar.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { TextField, IconButton, Box, InputAdornment } from '@mui/material'
 import { Search } from '@mui/icons-material'
 
-const SearchBar = ({ setSearchQuery }) => (
+const SearchBar = ({ setSearchQuery, props }) => (
   <form>
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <TextField
@@ -14,6 +14,7 @@ const SearchBar = ({ setSearchQuery }) => (
         variant="standard"
         size="small"
         placeholder="Search..."
+        sx={{ ...props }}
         slotProps={{
           input: {
             endAdornment: (

--- a/mentor-match-app/src/components/dashboard/UserListView.jsx
+++ b/mentor-match-app/src/components/dashboard/UserListView.jsx
@@ -1,6 +1,5 @@
 // React hooks
 import { useState } from 'react'
-import { useLocation } from 'react-router-dom'
 
 // MUI components
 import {
@@ -38,6 +37,7 @@ const UserListView = ({
   showChatButton,
   showViewProfileButton,
   showEndMentorshipButton,
+  showApplicationButton,
   onStartChat
 }) => {
   const [openDialog, setOpenDialog] = useState(false)
@@ -46,7 +46,6 @@ const UserListView = ({
     ? filterUsers(searchQuery, usersList)
     : []
   const { user, loading } = useUser()
-  const location = useLocation()
   const isDashboard = listType === 'dashboard'
   const isMentorPick = listType === 'mentorPick'
   const isCurrentMentees = listType === 'currentMentees'
@@ -58,6 +57,7 @@ const UserListView = ({
   const showSelectMentor = isMentorPick || showSelectAsMentorButton
   const showChat = isCurrentMentees || isAdmin || showChatButton
   const showEndMentorship = isCurrentMentees || showEndMentorshipButton
+  const showApplication = isCurrentMentees || showApplicationButton
 
   return (
     <Card
@@ -99,17 +99,6 @@ const UserListView = ({
                   Mentorship Program
                 </Button>
               )}
-              {/*               {showManageMenteesButton && (
-                <Tooltip title="Manage Mentees">
-                  <IconButton
-                    color="secondary"
-                    sx={{ height: 'min-content' }}
-                    onClick={() => setOpenDialog(true)}
-                  >
-                    <EditIcon />
-                  </IconButton>
-                </Tooltip>
-              )} */}
               <MentorshipFormDialog
                 openDialog={openDialog}
                 setOpenDialog={setOpenDialog}
@@ -137,6 +126,7 @@ const UserListView = ({
                       showChatButton={showChat}
                       showViewProfileButton={showProfile}
                       showEndMentorshipButton={showEndMentorship}
+                      showApplicationButton={showApplication}
                       onStartChat={onStartChat}
                     />
                   ))}

--- a/mentor-match-app/src/components/dialogs/CreateNewMatchDialog.jsx
+++ b/mentor-match-app/src/components/dialogs/CreateNewMatchDialog.jsx
@@ -1,0 +1,207 @@
+import { useState, useEffect } from 'react'
+import {
+  Dialog,
+  Checkbox,
+  DialogContent,
+  DialogActions,
+  DialogTitle,
+  Button,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemAvatar,
+  ListItemText,
+  Typography
+} from '@mui/material'
+import ProfilePicture from '../ProfilePicture'
+import SearchBar from '../dashboard/SearchBar'
+import { useUser } from '../../hooks/useUser'
+import { asignMatch } from '../../api/match'
+import { filterUsers } from '../../api/users'
+import { getCurrentApplicationStatus } from '../../api/forms'
+import { useSnackbar } from 'notistack'
+
+const CreateNewMatchDialog = ({ open, onClose, setReloadList }) => {
+  const { userList } = useUser()
+  const { enqueueSnackbar } = useSnackbar()
+  // Users that have a role
+  const usersWithRoles = userList.filter((user) => !!user.role)
+  const [applicationStatuses, setApplicationStatuses] = useState({}) // uid -> status
+  const [checked, setChecked] = useState([])
+  const [searchQuery, setSearchQuery] = useState('')
+
+  // Fetch current application status for each user with a role when dialog opens
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    const loadStatuses = async () => {
+      const entries = await Promise.all(
+        usersWithRoles.map(async (u) => {
+          try {
+            const res = await getCurrentApplicationStatus(u.uid, u.role)
+            console.log('Fetched application status for', u.uid, res.status)
+            return [u.uid, res.status]
+          } catch (e) {
+            console.error('Error fetching application status for', u.uid, e)
+            return [u.uid, null]
+          }
+        })
+      )
+      if (!cancelled) {
+        setApplicationStatuses(Object.fromEntries(entries))
+      }
+    }
+    loadStatuses()
+    return () => {
+      cancelled = true
+    }
+  }, [open, userList]) // re-fetch if list changes or dialog re-opens
+
+  // Only include users with BOTH a role AND accepted status (after fetch)
+  const eligibleUsers = usersWithRoles.filter(
+    (u) => applicationStatuses[u.uid] === 'approved'
+  )
+
+  const filteredUsers = filterUsers(searchQuery, eligibleUsers)
+
+  const handleToggle = (user) => () => {
+    console.log('Toggling user:', user)
+    const userKey = user.uid ?? user.displayName
+    const userRole = user.role
+    const currentIndex = checked.findIndex((item) => item.id === userKey)
+    const newChecked = [...checked]
+
+    if (currentIndex !== -1) {
+      newChecked.splice(currentIndex, 1)
+    } else {
+      // Only allow one Mentor and one Mentee
+      const hasMentor = newChecked.some((item) => item.role === 'Mentor')
+      const hasMentee = newChecked.some((item) => item.role === 'Mentee')
+      if (
+        (userRole === 'Mentor' && hasMentor) ||
+        (userRole === 'Mentee' && hasMentee) ||
+        newChecked.length >= 2
+      ) {
+        return
+      }
+      newChecked.push({ id: user.uid, role: userRole })
+    }
+    console.log(newChecked)
+    setChecked(newChecked)
+  }
+
+  const handleMatch = async () => {
+    if (checked.length !== 2) {
+      enqueueSnackbar('Please select one Mentor and one Mentee.', {
+        variant: 'warning'
+      })
+      return
+    }
+    const mentor = checked.find((item) => item.role === 'Mentor')
+    const mentee = checked.find((item) => item.role === 'Mentee')
+    if (!mentor || !mentee) {
+      enqueueSnackbar('Please select one Mentor and one Mentee.', {
+        variant: 'warning'
+      })
+      return
+    }
+
+    const menteeUser = userList.find((u) => u.uid === mentee.id)
+    console.log('Selected mentee user:', menteeUser)
+    if (menteeUser?.mentorId) {
+      enqueueSnackbar('Selected mentee already has a mentor assigned.', {
+        variant: 'error'
+      })
+      return
+    }
+
+    const result = await asignMatch(mentee.id, mentor.id)
+    if (result.ok) {
+      enqueueSnackbar('Match created successfully!', { variant: 'success' })
+      onClose()
+      setChecked([])
+      setReloadList(true)
+    } else {
+      enqueueSnackbar(`Error creating match: ${result.error}`, {
+        variant: 'error'
+      })
+    }
+  }
+
+  const isChecked = (user) => {
+    const userKey = user.uid ?? user.displayName
+    return checked.some((item) => item.id === userKey)
+  }
+
+  useEffect(() => {
+    if (!open) {
+      setChecked([])
+      setSearchQuery('')
+    }
+  }, [open])
+
+  return (
+    <Dialog open={open} onClose={onClose} maxHeight={'80hv'} overflow="auto">
+      <DialogTitle>Select a Mentor and Mentee to Match</DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body2" color="textSecondary" mb={2}>
+          Only users with an approved application status are shown on this list.
+        </Typography>
+        <SearchBar setSearchQuery={setSearchQuery} props={{ width: '100%' }} />
+        <List dense sx={{ width: '100%', bgcolor: 'background.paper' }}>
+          {filteredUsers.length === 0 && (
+            <ListItem>
+              <ListItemText primary="No users found." />
+            </ListItem>
+          )}
+          {filteredUsers.map((user, idx) => {
+            const userKey = user.uid ?? idx
+            const labelId = `checkbox-list-secondary-label-${userKey}`
+            return (
+              <ListItem
+                key={`user-${userKey}`}
+                secondaryAction={
+                  <Checkbox
+                    edge="end"
+                    onChange={handleToggle(user)}
+                    checked={isChecked(user)}
+                    id={labelId}
+                  />
+                }
+                sx={{ pl: 0 }}
+              >
+                <ListItemButton>
+                  <ListItemAvatar>
+                    <ProfilePicture
+                      img={user.profilePicture}
+                      size={40}
+                      borderRadius={100}
+                    />
+                  </ListItemAvatar>
+                  <ListItemText
+                    id={labelId}
+                    primary={user.displayName}
+                    secondary={user.role}
+                  />
+                </ListItemButton>
+              </ListItem>
+            )
+          })}
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => {
+            onClose()
+          }}
+        >
+          Cancel
+        </Button>
+        <Button onClick={handleMatch}>Create</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default CreateNewMatchDialog

--- a/mentor-match-app/src/components/dialogs/CreateNewMatchDialog.jsx
+++ b/mentor-match-app/src/components/dialogs/CreateNewMatchDialog.jsx
@@ -198,7 +198,9 @@ const CreateNewMatchDialog = ({ open, onClose, setReloadList }) => {
         >
           Cancel
         </Button>
-        <Button onClick={handleMatch}>Create</Button>
+        <Button onClick={handleMatch} color="success" variant="contained">
+          Create
+        </Button>
       </DialogActions>
     </Dialog>
   )

--- a/mentor-match-app/src/components/dialogs/EndMentorshipDialog.jsx
+++ b/mentor-match-app/src/components/dialogs/EndMentorshipDialog.jsx
@@ -19,12 +19,14 @@ const EndMentorshipDialog = ({
   openDialog,
   setOpenDialog,
   userId,
-  setOpenProfileDialog
+  setOpenProfileDialog,
+  menteeId,
+  mentorId
 }) => {
   const [selectedValue, setSelectedValue] = useState('')
   const [additionalInfo, setAdditionalInfo] = useState('')
   const { enqueueSnackbar } = useSnackbar()
-  const { user: loggedUser, refreshUser } = useUser()
+  const { user: loggedUser, refreshUser, isAdmin } = useUser()
 
   const handleValueChange = (event) => {
     setSelectedValue(event.target.value)
@@ -36,16 +38,24 @@ const EndMentorshipDialog = ({
 
   const handleSubmit = async () => {
     try {
-      console.log(
-        'logged user role:' +
-          loggedUser.role +
-          ', userId: ' +
-          userId +
-          ', loggedUser uid: ' +
-          loggedUser.uid
-      )
       let res
-      if (
+      if (isAdmin) {
+        if (!menteeId || !mentorId) {
+          enqueueSnackbar('Missing menteeId or mentorId.', { variant: 'error' })
+          return
+        }
+        console.log(
+          'Admin ending mentorship (menteeId->mentorId):',
+          menteeId,
+          mentorId
+        )
+        res = await endMentorship(
+          menteeId,
+          mentorId,
+          selectedValue,
+          additionalInfo
+        )
+      } else if (
         (loggedUser.role === 'Mentor' || loggedUser.role === 'Mentor/Mentee') &&
         loggedUser.mentees.includes(userId)
       ) {

--- a/mentor-match-app/src/components/dialogs/formReview/MenteeApplicationDialog.jsx
+++ b/mentor-match-app/src/components/dialogs/formReview/MenteeApplicationDialog.jsx
@@ -30,7 +30,8 @@ const MenteeApplicationDialog = ({
   application,
   open,
   onClose,
-  onStatusUpdate
+  onStatusUpdate,
+  enableReview = true
 }) => {
   const { user, formData } = application || {}
   const [openAcceptDialog, setOpenAcceptDialog] = useState(false)
@@ -115,22 +116,36 @@ const MenteeApplicationDialog = ({
           </Formik>
         </Container>
       </DialogContent>
+
       <DialogActions>
-        <Button
-          variant="contained"
-          color="error"
-          onClick={() => setOpenRejectDialog(true)}
-        >
-          Reject Application
-        </Button>
-        <Button
-          variant="contained"
-          color="success"
-          onClick={() => setOpenAcceptDialog(true)}
-        >
-          Accept Application
-        </Button>
+        {!enableReview ? (
+          <Button
+            onClick={() => {
+              onClose()
+            }}
+          >
+            Close
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={() => setOpenRejectDialog(true)}
+            >
+              Reject Application
+            </Button>
+            <Button
+              variant="contained"
+              color="success"
+              onClick={() => setOpenAcceptDialog(true)}
+            >
+              Accept Application
+            </Button>
+          </>
+        )}
       </DialogActions>
+
       <ConfirmApplicationDialog
         open={openAcceptDialog}
         onClose={() => setOpenAcceptDialog(false)}

--- a/mentor-match-app/src/hooks/useUser.jsx
+++ b/mentor-match-app/src/hooks/useUser.jsx
@@ -89,8 +89,8 @@ const UserProvider = ({ children }) => {
 
   useEffect(() => {
     const fetchMenteeList = async () => {
-      if (user && user.mentees) {
-        const menteeArr = await getUserArrayByIds(user.mentees)
+      if (user && user.menteesId) {
+        const menteeArr = await getUserArrayByIds(user.menteesId)
         setMentees(menteeArr)
       }
     }

--- a/mentor-match-app/src/pages/AdminDashboard.jsx
+++ b/mentor-match-app/src/pages/AdminDashboard.jsx
@@ -20,6 +20,7 @@ import CombinedApplicationDialog from '../components/dialogs/formReview/Combined
 import { getPendingApplications } from '../api/forms'
 import { useNavigate } from 'react-router-dom'
 import { Person as UserIcon } from '@mui/icons-material'
+import ManageMatchesSection from '../components/adminDashboard/ManageMatchesSection'
 
 const AdminDashboard = () => {
   const { userList } = useUser()
@@ -121,7 +122,7 @@ const AdminDashboard = () => {
                   >
                     <Tab label="Users" value="0" />
                     <Tab label="Mentorship Applications" value="1" />
-                    {/* <Tab label="Manage Matches" value="2" /> */}
+                    <Tab label="Manage Matches" value="2" />
                   </TabList>
                   <Box flexGrow={1} />
                   <Button
@@ -167,7 +168,9 @@ const AdminDashboard = () => {
                     </Stack>
                   )}
                 </TabPanel>
-                <TabPanel value="2">Item Three</TabPanel>
+                <TabPanel value="2">
+                  <ManageMatchesSection />
+                </TabPanel>
               </TabContext>
             </Box>
           </Card>

--- a/mentor-match-app/src/pages/Dashboard.jsx
+++ b/mentor-match-app/src/pages/Dashboard.jsx
@@ -38,7 +38,9 @@ const Dashboard = () => {
   const [loadingMentor, setLoadingMentor] = useState(false)
   const [toggleChat, setToggleChat] = useState(false)
   const [selectedChatRoomId, setSelectedChatRoomId] = useState(null)
+  const [showAlert, setShowAlert] = useState(true)
   const navigate = useNavigate()
+
   useEffect(() => {
     if (user) {
       // Filter out the logged-in user and ensure only public profiles are shown for non-admin users
@@ -126,7 +128,12 @@ const Dashboard = () => {
               </Stack>
               <Stack spacing={2}>
                 {/* TODO: Show match alert when theres a new mentee match or when mentor match results are ready */}
-                {user.newMenteeMatch && <MatchAlert setView={setViewType} />}
+                {user.newMenteeMatch && showAlert && (
+                  <MatchAlert
+                    setView={setViewType}
+                    setShowAlert={setShowAlert}
+                  />
+                )}
 
                 {user && viewType === 'dashboard' && (
                   <UserListView

--- a/mentor-match-app/src/pages/Dashboard.jsx
+++ b/mentor-match-app/src/pages/Dashboard.jsx
@@ -126,7 +126,7 @@ const Dashboard = () => {
               </Stack>
               <Stack spacing={2}>
                 {/* TODO: Show match alert when theres a new mentee match or when mentor match results are ready */}
-                {false && <MatchAlert setView={setViewType} />}
+                {user.newMenteeMatch && <MatchAlert setView={setViewType} />}
 
                 {user && viewType === 'dashboard' && (
                   <UserListView


### PR DESCRIPTION
- Admin users can create, end, and reassign mentorship matches from the admin dashboard. Closes #37 
- Added profile dialogs for matches in the 'Manage matches' section, so admins can view the users' profiles.
- Mentors can now view their mentee's application form from the main dashboard.